### PR TITLE
DL-9506 update play frontend hmrc to latest plus other dependencies

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,7 +18,7 @@ appName="national-insurance-uplift-calculator-frontend"
 
 play.http.router = prod.Routes
 
-play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:12500 localhost:9032 localhost:9250 localhost:12345 www.google-analytics.com www.googletagmanager.com"
+play.filters.csp.CSPFilter = "default-src 'self' 'unsafe-inline' localhost:12500 localhost:9032 localhost:9250 localhost:12345 www.google-analytics.com www.googletagmanager.com"
 
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.http.errorHandler = "handlers.ErrorHandler"
@@ -27,7 +27,7 @@ play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters
 
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.FrontendModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,22 +5,22 @@ object AppDependencies {
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"             % "4.1.0-play-28",
-    "uk.gov.hmrc"       %% "play-conditional-form-mapping"  % "1.11.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"             % "6.2.0-play-28",
+    "uk.gov.hmrc"       %% "play-conditional-form-mapping"  % "1.12.0-play-28",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"     % "5.25.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"             % "0.68.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"             % "0.74.0"
   )
 
   val test = Seq(
-    "org.scalatest"           %% "scalatest"               % "3.2.12",
+    "org.scalatest"           %% "scalatest"               % "3.2.15",
     "org.scalatestplus"       %% "scalacheck-1-15"         % "3.2.11.0",
     "org.scalatestplus"       %% "mockito-3-4"             % "3.2.10.0",
     "org.scalatestplus.play"  %% "scalatestplus-play"      % "5.1.0",
-    "org.jsoup"               %  "jsoup"                   % "1.15.2",
+    "org.jsoup"               %  "jsoup"                   % "1.15.3",
     "com.typesafe.play"       %% "play-test"               % PlayVersion.current,
-    "org.mockito"             %% "mockito-scala"           % "1.17.7",
-    "org.scalacheck"          %% "scalacheck"              % "1.16.0",
-    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28" % "0.68.0",
+    "org.mockito"             %% "mockito-scala"           % "1.17.12",
+    "org.scalacheck"          %% "scalacheck"              % "1.17.0",
+    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28" % "0.74.0",
     "com.vladsch.flexmark"    %  "flexmark-all"            % "0.62.2"
   ).map(_ % "test, it")
 


### PR DESCRIPTION
Upgrade play frontend hmrc to latest
Other dependency updates
Address warnings in logs for deprecated play filters